### PR TITLE
Add it to CocoaPods

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Peter Iakovlev
+Contributor (c) 2015 Paulo Miguel Almeida Rodenas <paulo.ubuntu@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Signals
+
+An experimental Rx- and RAC-3.0-inspired FRP framework
+
+## Requirements
+
+- iOS 6.0+
+- Xcode 5.0+
+
+### CocoaPods
+
+[CocoaPods](http://cocoapods.org) is a dependency manager for Cocoa projects.
+
+You can install it with the following command:
+
+```bash
+$ gem install cocoapods
+```
+
+To integrate SSignalKit into your Xcode project using CocoaPods, specify it in your `Podfile`:
+
+```ruby
+source 'https://github.com/CocoaPods/Specs.git'
+platform :ios, '6.0'
+
+pod 'SSignalKit', '~> 0.0.1'
+```
+
+Then, run the following command:
+
+```bash
+$ pod install
+```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To integrate SSignalKit into your Xcode project using CocoaPods, specify it in y
 source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '6.0'
 
-pod 'SSignalKit', '~> 0.0.1'
+pod 'SSignalKit', '~> 0.0.2'
 ```
 
 Then, run the following command:

--- a/SSignalKit.podspec
+++ b/SSignalKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "SSignalKit"
-  s.version      = "0.0.1"
+  s.version      = "0.0.2"
   s.summary      = "An experimental Rx- and RAC-3.0-inspired FRP framework"
   s.homepage     = "https://github.com/PauloMigAlmeida/Signals"
   s.license      = "MIT"
@@ -9,7 +9,8 @@ Pod::Spec.new do |s|
   s.authors            = { "Peter Iakovlev" => '', "Paulo Miguel Almeida" => "paulo.ubuntu@gmail.com" }
   s.social_media_url   = 'http://twitter.com/PauloMigAlmeida'
 
-  s.platform     = :ios, "6.0"
+  s.ios.deployment_target = "6.0"
+  s.osx.deployment_target = "10.7"
 
   s.source       = { :git => "https://github.com/PauloMigAlmeida/Signals.git", :tag => "0.0.1" }
   s.source_files  = "SSignalKit/**/*.{h,m}"

--- a/SSignalKit.podspec
+++ b/SSignalKit.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "6.0"
   s.osx.deployment_target = "10.7"
 
-  s.source       = { :git => "https://github.com/PauloMigAlmeida/Signals.git", :tag => "0.0.1" }
+  s.source       = { :git => "https://github.com/PauloMigAlmeida/Signals.git", :tag => s.version }
   s.source_files  = "SSignalKit/**/*.{h,m}"
   s.requires_arc = true
 

--- a/SSignalKit.podspec
+++ b/SSignalKit.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+
+  s.name         = "SSignalKit"
+  s.version      = "0.0.1"
+  s.summary      = "An experimental Rx- and RAC-3.0-inspired FRP framework"
+  s.homepage     = "https://github.com/PauloMigAlmeida/Signals"
+  s.license      = "MIT"
+
+  s.authors            = { "Peter Iakovlev" => '', "Paulo Miguel Almeida" => "paulo.ubuntu@gmail.com" }
+  s.social_media_url   = 'http://twitter.com/PauloMigAlmeida'
+
+  s.platform     = :ios, "6.0"
+
+  s.source       = { :git => "https://github.com/PauloMigAlmeida/Signals.git", :tag => "0.0.1" }
+  s.source_files  = "SSignalKit/**/*.{h,m}"
+  s.requires_arc = true
+
+end

--- a/SSignalKit.xcodeproj/project.pbxproj
+++ b/SSignalKit.xcodeproj/project.pbxproj
@@ -61,7 +61,6 @@
 		D0085B1C1B28285400EAF753 /* STimer.m in Sources */ = {isa = PBXBuildFile; fileRef = D0085AE61B28285400EAF753 /* STimer.m */; };
 		D0085B271B282B9800EAF753 /* SwiftSignalKit.h in Headers */ = {isa = PBXBuildFile; fileRef = D0085B261B282B9800EAF753 /* SwiftSignalKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D0085B2D1B282B9800EAF753 /* SwiftSignalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0085B221B282B9800EAF753 /* SwiftSignalKit.framework */; };
-		D0085B4F1B282BEE00EAF753 /* SwiftSignalKit.h in Headers */ = {isa = PBXBuildFile; fileRef = D0085B3B1B282BEE00EAF753 /* SwiftSignalKit.h */; };
 		D0085B501B282BEE00EAF753 /* Signal_Timing.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0085B3C1B282BEE00EAF753 /* Signal_Timing.swift */; };
 		D0085B511B282BEE00EAF753 /* Signal_SideEffects.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0085B3D1B282BEE00EAF753 /* Signal_SideEffects.swift */; };
 		D0085B521B282BEE00EAF753 /* Signal_Dispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0085B3E1B282BEE00EAF753 /* Signal_Dispatch.swift */; };
@@ -409,7 +408,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				D0085B271B282B9800EAF753 /* SwiftSignalKit.h in Headers */,
-				D0085B4F1B282BEE00EAF753 /* SwiftSignalKit.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -529,7 +527,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0610;
+				LastUpgradeCheck = 0640;
 				ORGANIZATIONNAME = Telegram;
 				TargetAttributes = {
 					D0085B211B282B9800EAF753 = {


### PR DESCRIPTION
This PR aims to add SSignalKit to CocoaSpec repository. However there are a couple things I couldn't figure out and I need a couple answers.
- What License you're releasing this project ?
  
  As I couldn't find out which one you want to use I've added temporally the MIT license with your name as it's the most common one nowadays. Feel free to change it if you want to ;)
- I saw you have two different implementations ( Objective-C and Swift ), but as far as I've googled I can't have two different implementations with different bundle ids under the same repository on CocoaPods. So my question is: May you move the Swift implementation to another project ?

If you think this is a good improvement to your repo, please accept this PR.

Best Regards
